### PR TITLE
Added connection status check before WiFi.begin

### DIFF
--- a/src/wifi/AdafruitIO_ESP8266.cpp
+++ b/src/wifi/AdafruitIO_ESP8266.cpp
@@ -32,12 +32,13 @@ AdafruitIO_ESP8266::~AdafruitIO_ESP8266()
 
 void AdafruitIO_ESP8266::_connect()
 {
-
   delay(100);
-  WiFi.begin(_ssid, _pass);
+  if (networkStatus() < 20) { // only try to connect if ESP8266 isn't already connected
+    WiFi.mode(WIFI_STA); // force ESP8266 into STATION mode (working on AP+STA implementation)
+    WiFi.begin(_ssid, _pass);
+    _status = AIO_NET_DISCONNECTED;
+  }
   delay(100);
-  _status = AIO_NET_DISCONNECTED;
-
 }
 
 aio_status_t AdafruitIO_ESP8266::networkStatus()


### PR DESCRIPTION
During a troubleshooting session on Discord #adafruit-io with @seckela on late 16 November to early 17 November, we discovered that if a WiFi connection is already established, the Adafruit IO library would not proceed past `io.connect()`. I added a `networkStatus()` check before calling `WiFi.begin` to avoid getting stuck in `io.connect()`. 

Also, I added a call to force the ESP8266 into Station mode; I ran into a problem of persistent AP+STA mode and couldn't get out of it.

Thank you for creating a pull request to contribute to Adafruit's GitHub code!
Before you open the request please review the following guidelines and tips to
help it be more easily integrated:

- **Describe the scope of your change--i.e. what the change does and what parts
  of the code were modified.**  This will help us understand any risks of integrating
  the code.

- **Describe any known limitations with your change.**  For example if the change
  doesn't apply to a supported platform of the library please mention it.

- **Please run any tests or examples that can exercise your modified code.**  We
  strive to not break users of the code and running tests/examples helps with this
  process.

Thank you again for contributing!  We will try to test and integrate the change
as soon as we can, but be aware we have many GitHub repositories to manage and
can't immediately respond to every request.  There is no need to bump or check in
on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated--sometimes the
priorities of Adafruit's GitHub code (education, ease of use) might not match the
priorities of the pull request.  Don't fret, the open source community thrives on
forks and GitHub makes it easy to keep your changes in a forked repo.

After reviewing the guidelines above you can delete this text from the pull request.
